### PR TITLE
Ignore templates if user may not read repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Ignore templates if user may not read repository ([#2](https://github.com/scm-manager/scm-repository-template-plugin/pull/2))
+
 ## 1.0.1 - 2020-09-11
 ### Fixed
 - Check if template file is not a directory

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <artifactId>scm-plugins</artifactId>
     <groupId>sonia.scm.plugins</groupId>
-    <version>2.5.0</version>
+    <version>2.12.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scm-repository-template-plugin</artifactId>

--- a/src/main/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplate.java
+++ b/src/main/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplate.java
@@ -26,6 +26,8 @@ package com.cloudogu.scm.repositorytemplate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import sonia.scm.repository.NamespaceAndName;
+import sonia.scm.repository.Repository;
 
 import java.util.List;
 
@@ -33,12 +35,27 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 public class RepositoryTemplate {
-  private String templateRepository;
+  private NamespaceAndName namespaceAndName;
+  private String repositoryId;
   private String engine;
   private String encoding;
   private List<RepositoryTemplateFile> files;
 
-  public RepositoryTemplate(String templateRepository) {
-    this.templateRepository = templateRepository;
+  public RepositoryTemplate(Repository repository) {
+    this(repository.getNamespaceAndName(), repository.getId());
+  }
+
+  private RepositoryTemplate(NamespaceAndName namespaceAndName, String repositoryId) {
+    this.namespaceAndName = namespaceAndName;
+    this.repositoryId = repositoryId;
+  }
+
+  public String getTemplateRepository() {
+    return namespaceAndName.toString();
+  }
+
+  void setRepository(Repository repository) {
+    this.namespaceAndName = repository.getNamespaceAndName();
+    this.repositoryId = repository.getId();
   }
 }

--- a/src/main/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplateCollector.java
+++ b/src/main/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplateCollector.java
@@ -40,6 +40,7 @@ import sonia.scm.repository.api.RepositoryServiceFactory;
 import sonia.scm.web.security.AdministrationContext;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -49,6 +50,7 @@ import java.util.Optional;
 import static com.cloudogu.scm.repositorytemplate.RepositoryTemplateFinder.TEMPLATE_YAML;
 import static com.cloudogu.scm.repositorytemplate.RepositoryTemplateFinder.TEMPLATE_YML;
 
+@Singleton
 public class RepositoryTemplateCollector {
 
   private static final Logger LOG = LoggerFactory.getLogger(RepositoryTemplateCollector.class);

--- a/src/main/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplater.java
+++ b/src/main/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplater.java
@@ -144,14 +144,15 @@ public class RepositoryTemplater {
 
   private RepositoryTemplate parseTemplateConfig(RepositoryService repositoryService) throws IOException {
     Optional<String> templateFile = RepositoryTemplateFinder.templateFileExists(repositoryService);
+    Repository repository = repositoryService.getRepository();
     if (!templateFile.isPresent()) {
       throw NotFoundException.notFound(
-        ContextEntry.ContextBuilder.entity(RepositoryTemplate.class, "template file").in(repositoryService.getRepository())
+        ContextEntry.ContextBuilder.entity(RepositoryTemplate.class, "template file").in(repository)
       );
     }
     try (InputStream templateYml = repositoryService.getCatCommand().getStream(templateFile.get())) {
       RepositoryTemplate repositoryTemplate = unmarshallRepositoryTemplate(templateFile.get(), templateYml);
-      repositoryTemplate.setTemplateRepository(repositoryService.getRepository().getNamespaceAndName().toString());
+      repositoryTemplate.setRepository(repository);
       if (repositoryTemplate.getFiles() == null) {
         repositoryTemplate.setFiles(Collections.emptyList());
       }

--- a/src/test/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplateCollectorTest.java
+++ b/src/test/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplateCollectorTest.java
@@ -166,7 +166,6 @@ class RepositoryTemplateCollectorTest {
   @Test
   void shouldCollectRepositoryTemplatesFromCache() {
     when(subject.isPermitted("repository:read:" + REPOSITORY.getId())).thenReturn(true);
-    when(repositoryManager.get(new NamespaceAndName(REPOSITORY.getNamespace(), REPOSITORY.getName()))).thenReturn(REPOSITORY);
 
     List<RepositoryTemplate> repositoryTemplates = createRepoTemplateList(
       "hitchhiker",
@@ -188,7 +187,6 @@ class RepositoryTemplateCollectorTest {
   @Test
   void shouldNotCollectRepositoryTemplatesFromCacheForUserWithoutReadPermission() {
     when(subject.isPermitted("repository:read:" + REPOSITORY.getId())).thenReturn(false);
-    when(repositoryManager.get(new NamespaceAndName(REPOSITORY.getNamespace(), REPOSITORY.getName()))).thenReturn(REPOSITORY);
 
     List<RepositoryTemplate> repositoryTemplates = createRepoTemplateList(
       "hitchhiker",
@@ -208,7 +206,6 @@ class RepositoryTemplateCollectorTest {
       createRepoTemplateList("hitchhiker", new RepositoryTemplateFile(".gitignore", false));
 
     cacheManager.getCache(CACHE_NAME).put("templates", repositoryTemplates);
-    when(repositoryManager.get(new NamespaceAndName(REPOSITORY.getNamespace(), REPOSITORY.getName()))).thenReturn(REPOSITORY);
 
     Collection<RepositoryTemplate> templates = collector.collect();
 
@@ -280,7 +277,7 @@ class RepositoryTemplateCollectorTest {
 
   private List<RepositoryTemplate> createRepoTemplateList(String engine, RepositoryTemplateFile... templateFiles) {
     RepositoryTemplate repositoryTemplate = new RepositoryTemplate();
-    repositoryTemplate.setTemplateRepository(REPOSITORY.getNamespaceAndName().toString());
+    repositoryTemplate.setRepository(REPOSITORY);
     repositoryTemplate.setEngine(engine);
     repositoryTemplate.setFiles(Arrays.asList(templateFiles.clone()));
     List<RepositoryTemplate> repositoryTemplates = new ArrayList<>();

--- a/src/test/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplateCollectorTest.java
+++ b/src/test/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplateCollectorTest.java
@@ -186,6 +186,23 @@ class RepositoryTemplateCollectorTest {
   }
 
   @Test
+  void shouldNotCollectRepositoryTemplatesFromCacheForUserWithoutReadPermission() {
+    when(subject.isPermitted("repository:read:" + REPOSITORY.getId())).thenReturn(false);
+    when(repositoryManager.get(new NamespaceAndName(REPOSITORY.getNamespace(), REPOSITORY.getName()))).thenReturn(REPOSITORY);
+
+    List<RepositoryTemplate> repositoryTemplates = createRepoTemplateList(
+      "hitchhiker",
+      new RepositoryTemplateFile(".gitignore", false),
+      new RepositoryTemplateFile("Jenkinsfile", true)
+    );
+    cacheManager.getCache(CACHE_NAME).put("templates", repositoryTemplates);
+
+    Collection<RepositoryTemplate> templates = collector.collect();
+
+    assertThat(templates).isEmpty();
+  }
+
+  @Test
   void shouldNotCollectRepositoryTemplatesFromCacheWithoutPermission() {
     List<RepositoryTemplate> repositoryTemplates =
       createRepoTemplateList("hitchhiker", new RepositoryTemplateFile(".gitignore", false));

--- a/src/test/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplateMapperTest.java
+++ b/src/test/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplateMapperTest.java
@@ -39,7 +39,7 @@ class RepositoryTemplateMapperTest {
   @Test
   void shouldMapRepoTemplateToDto() {
     Repository repository = RepositoryTestData.create42Puzzle();
-    RepositoryTemplate repositoryTemplate = new RepositoryTemplate(repository.getNamespaceAndName().toString());
+    RepositoryTemplate repositoryTemplate = new RepositoryTemplate(repository);
 
     RepositoryTemplateDto dto = mapper.map(repositoryTemplate);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7979,9 +7979,9 @@ react-select@^2.1.2:
     react-input-autosize "^2.2.1"
     react-transition-group "^2.2.1"
 
-"react-syntax-highlighter@git+https://github.com/conorhastings/react-syntax-highlighter.git#08bcf49b1aa7877ce94f7208e73dfa6bef8b26e7":
+"react-syntax-highlighter@https://github.com/conorhastings/react-syntax-highlighter#08bcf49b1aa7877ce94f7208e73dfa6bef8b26e7":
   version "12.0.2"
-  resolved "git+https://github.com/conorhastings/react-syntax-highlighter.git#08bcf49b1aa7877ce94f7208e73dfa6bef8b26e7"
+  resolved "https://github.com/conorhastings/react-syntax-highlighter#08bcf49b1aa7877ce94f7208e73dfa6bef8b26e7"
   dependencies:
     "@babel/runtime" "^7.3.1"
     highlight.js "~9.13.0"


### PR DESCRIPTION
## Proposed changes

Fix permission error which appeared when a user wanted to initialize a new repository and was accessing templates in repositories which he may not read.

Reproduction:
- Create repository with template file
- Create user which may only "create repositories"
- Try to create a new repository with initialization logged in as this limited user 

### Your checklist for this pull request

- [x] PR is well described
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
