### PR TITLE
Repos created from templates should not immediately become templates themselves

### DIFF
--- a/gradle/changelog/dont_copy_template_file.yaml
+++ b/gradle/changelog/dont_copy_template_file.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Repos created from templates should not immediately become templates themselves ([#12](https://github.com/scm-manager/scm-repository-template-plugin/pull/12))

--- a/src/main/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplater.java
+++ b/src/main/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplater.java
@@ -115,6 +115,9 @@ public class RepositoryTemplater {
   }
 
   private void copyToTargetRepository(RepositoryService templateService, TemplateFilter filter, RepositoryTemplateFile templateFile, String filePath) throws IOException {
+    if (filePath.equals(RepositoryTemplateFinder.TEMPLATE_YML) || filePath.equals(RepositoryTemplateFinder.TEMPLATE_YAML)) {
+      return;
+    }
     try (InputStream content = templateService.getCatCommand().getStream(filePath)) {
       if (templateFile.isFiltered()) {
         copyFileTemplated(filter, content, filePath);

--- a/src/test/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplaterTest.java
+++ b/src/test/java/com/cloudogu/scm/repositorytemplate/RepositoryTemplaterTest.java
@@ -168,6 +168,26 @@ class RepositoryTemplaterTest {
   }
 
   @Test
+  void shouldNotCopyTemplateYaml() throws IOException {
+    mockTemplateService("com/cloudogu/scm/repositorytemplate/template_with_template_yaml.yml");
+
+    FileObject templateYml = createFileObject("template.yml");
+    FileObject templateYaml = createFileObject("template.yaml");
+    FileObject docsMd = createFileObject("src/main/docs.md");
+    FileObject buildMd = createFileObject("src/main/template.yml");
+    FileObject packageMd = createFileObject("src/main/packageMd.md");
+    FileObject main = createFileObject("src/main", ImmutableList.of(docsMd, buildMd, packageMd));
+    FileObject src = createFileObject("src", ImmutableList.of(main));
+    createFileObject("", ImmutableList.of(templateYml, templateYaml, src));
+
+    when(context.create(anyString())).thenReturn(createFile);
+
+    repositoryTemplater.render(TEMPLATE_REPOSITORY, context);
+
+    verify(context, times(3)).create(anyString());
+  }
+
+  @Test
   void shouldCopyAndTemplateDirectoryRecursively() throws IOException {
     mockTemplateService("com/cloudogu/scm/repositorytemplate/template_only_dir.yml");
 

--- a/src/test/resources/com/cloudogu/scm/repositorytemplate/template_with_template_yaml.yml
+++ b/src/test/resources/com/cloudogu/scm/repositorytemplate/template_with_template_yaml.yml
@@ -1,0 +1,31 @@
+#
+# MIT License
+#
+# Copyright (c) 2020-present Cloudogu GmbH and Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+engine: mustache
+files:
+  - path: src
+    filtered: false
+  - path: template.yml
+    filtered: false
+encoding: UTF-8

--- a/src/test/resources/com/cloudogu/scm/repositorytemplate/template_with_template_yaml.yml
+++ b/src/test/resources/com/cloudogu/scm/repositorytemplate/template_with_template_yaml.yml
@@ -28,4 +28,6 @@ files:
     filtered: false
   - path: template.yml
     filtered: false
+  - path: template.yaml
+    filtered: false
 encoding: UTF-8


### PR DESCRIPTION
## Proposed changes

With the initial release of this plugin, the template file was copied whenever the template was used for initialization. This caused the created repository to also be a template. This behaviour is fixed with this pull request.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
